### PR TITLE
Fix bug in Column::Stats generation

### DIFF
--- a/spec/models/column_stats_spec.rb
+++ b/spec/models/column_stats_spec.rb
@@ -25,7 +25,7 @@ describe Column::Stats do
 
   describe '.pick' do
     before do
-      @column = create(:stats_column, min: 1, max: 2, max_per: 2)
+      @column = create(:stats_column, min: 1, max: 5, max_per: 2)
     end
 
     describe 'with enough options to assign all points' do
@@ -38,8 +38,7 @@ describe Column::Stats do
       end
 
       it 'assigns all points correctly' do
-        total_assigned_points = @stat_values.sum - (@stat_values.length * @column.min)
-        expect(total_assigned_points).to eq @column.max
+        expect(@stat_values.sum).to eq @column.max
       end
 
       it 'applies up to max_per per option' do

--- a/spec/models/generator_generate_spec.rb
+++ b/spec/models/generator_generate_spec.rb
@@ -16,7 +16,7 @@ describe Generator do
 
     describe 'with a stats column' do
       before do
-        @column = create(:stats_column, min: 1, max: 2, max_per: 2, parent_generators: [@generator])
+        @column = create(:stats_column, min: 1, max: 5, max_per: 2, parent_generators: [@generator])
       end
 
       describe 'with enough options to assign all points' do
@@ -29,8 +29,7 @@ describe Generator do
         end
 
         it 'assigns all points correctly' do
-          total_assigned_points = @stat_values.sum - (@stat_values.length * @column.min)
-          expect(total_assigned_points).to eq @column.max
+          expect(@stat_values.sum).to eq @column.max
         end
 
         it 'applies up to max_per per option' do


### PR DESCRIPTION
It wasn’t taking into account the minimum correctly and wasn’t making sure that the total generated matched the max exactly.