### PR TITLE
Add exclusive options to option info in responses

### DIFF
--- a/app/views/api/v1/generators/_option.json.jbuilder
+++ b/app/views/api/v1/generators/_option.json.jbuilder
@@ -1,3 +1,4 @@
 json.(option, :id, :text)
 json.weight option.weight if option.weight
 json.columns option.columns.old_to_new, partial: 'api/v1/generators/column', as: :column
+json.exclusive_options (option.excluded_options - [option]).map(&:id)

--- a/spec/controllers/api/v1/generators_controller/show_spec.rb
+++ b/spec/controllers/api/v1/generators_controller/show_spec.rb
@@ -33,6 +33,7 @@ describe Api::V1::GeneratorsController do
             'id' => @option.id,
             'text' => @option.text,
             'weight' => @option.weight,
+            'exclusive_options' => [@option_two.id],
             'columns' => [{
               'id' => @option_column.id,
               'name' => @option_column.name,
@@ -52,6 +53,7 @@ describe Api::V1::GeneratorsController do
             'text' => @option_two.text,
             'weight' => @option_two.weight,
             'columns' => [],
+            'exclusive_options' => [@option.id]
           },
         ],
         'exclusion_sets' => [


### PR DESCRIPTION
Makes it easier to know which options are incompatible with the current option if it's attached right onto the option rather than having to traverse upwards and parse the column's exclusion_sets.