### PR TITLE
Remove compile assets from deploy.rb.example

### DIFF
--- a/config/deploy.rb.example
+++ b/config/deploy.rb.example
@@ -48,7 +48,6 @@ task deploy: :environment do
     invoke :'deploy:link_shared_paths'
     invoke :'bundle:install'
     invoke :'rails:db_migrate'
-    invoke :'compile_assets'
     invoke :'deploy:cleanup'
     invoke :'unicorn:stop'
     invoke :'unicorn:start'


### PR DESCRIPTION
It should not longer be triggered during deploy